### PR TITLE
feat: provide load balance and load balance config

### DIFF
--- a/constants/dial.go
+++ b/constants/dial.go
@@ -1,0 +1,16 @@
+package constants
+
+import "github.com/LotteWong/giotto-gateway/load_balance/lb_algos"
+
+const (
+	DefaultDialMethod    = 0
+	DefaultDialTimeout   = 5
+	DefaultDialMaxErrNum = 3
+	DefaultDialInterval  = 5
+
+	DefaultReplicas = 10
+)
+
+var (
+	DefaultHashFunc lb_algos.HashFunc = nil
+)

--- a/constants/type.go
+++ b/constants/type.go
@@ -10,6 +10,11 @@ const (
 
 	Disable = 0
 	Enable  = 1
+
+	LbTypeRandom           = 0
+	LbTypeRoundRobin       = 1
+	LbTypeWeightRoundRobin = 2
+	LbTypeConsistentHash   = 3
 )
 
 var (

--- a/load_balance/factory.go
+++ b/load_balance/factory.go
@@ -1,0 +1,73 @@
+package load_balance
+
+import (
+	"github.com/LotteWong/giotto-gateway/constants"
+	"github.com/LotteWong/giotto-gateway/load_balance/lb_algos"
+)
+
+type LbType int
+
+type LoadBalance interface {
+	Add(...string) error
+	Rmv(...string) error
+	Get(string) (string, error)
+
+	Subscribe()
+}
+
+type LoadBalanceConf interface {
+	GetConf() []*IpAndWeight
+
+	Attach(lb LoadBalance)
+	Publish()
+}
+
+type IpAndWeight struct {
+	Ip     string
+	Weight int
+}
+
+func LoadBalanceFactory(lbType LbType) LoadBalance {
+	switch lbType {
+	case constants.LbTypeRandom:
+		return lb_algos.NewRandomLb()
+	case constants.LbTypeRoundRobin:
+		return lb_algos.NewRoundRobinLb()
+	case constants.LbTypeWeightRoundRobin:
+		return lb_algos.NewWeightRoundRobinLb()
+	case constants.LbTypeConsistentHash:
+		return lb_algos.NewConsistentHashLb(constants.DefaultReplicas, constants.DefaultHashFunc)
+	default:
+		return lb_algos.NewRandomLb()
+	}
+}
+
+func LoadBalanceWithConfFactory(lbType LbType, conf LoadBalanceConf) LoadBalance {
+	switch lbType {
+	case constants.LbTypeRandom:
+		lb := lb_algos.NewRandomLb()
+		lb.Register(conf)
+		lb.Subscribe()
+		return lb
+	case constants.LbTypeRoundRobin:
+		lb := lb_algos.NewRoundRobinLb()
+		lb.Register(conf)
+		lb.Subscribe()
+		return lb
+	case constants.LbTypeWeightRoundRobin:
+		lb := lb_algos.NewWeightRoundRobinLb()
+		lb.Register(conf)
+		lb.Subscribe()
+		return lb
+	case constants.LbTypeConsistentHash:
+		lb := lb_algos.NewConsistentHashLb(constants.DefaultReplicas, constants.DefaultHashFunc)
+		lb.Register(conf)
+		lb.Subscribe()
+		return lb
+	default:
+		lb := lb_algos.NewRandomLb()
+		lb.Register(conf)
+		lb.Subscribe()
+		return lb
+	}
+}

--- a/load_balance/lb_algos/consistent_hash.go
+++ b/load_balance/lb_algos/consistent_hash.go
@@ -1,0 +1,114 @@
+package lb_algos
+
+import (
+	"github.com/LotteWong/giotto-gateway/load_balance"
+	"github.com/LotteWong/giotto-gateway/load_balance/lb_conf"
+	"github.com/pkg/errors"
+	"hash/crc32"
+	"sort"
+	"strconv"
+	"sync"
+)
+
+type HashFunc func(data []byte) uint32
+
+type HashRing []uint32
+
+func (r HashRing) Len() int {
+	return len(r)
+}
+
+func (r HashRing) Less(i, j int) bool {
+	return r[i] < r[j]
+}
+
+func (r HashRing) Swap(i, j int) {
+	r[i], r[j] = r[j], r[i]
+}
+
+type ConsistentHashLb struct {
+	hashMap  map[uint32]string // key is hash, value is ip
+	hashRing HashRing
+	hashFunc HashFunc
+	replicas int
+	RWLock   sync.RWMutex
+	conf     load_balance.LoadBalanceConf
+}
+
+func NewConsistentHashLb(replicas int, function HashFunc) *ConsistentHashLb {
+	if replicas == 0 {
+		replicas = 1 // set default replicas to 1
+	}
+	if function == nil {
+		function = crc32.ChecksumIEEE // set default hash func as crc32
+	}
+	lb := &ConsistentHashLb{
+		hashMap:  make(map[uint32]string),
+		hashRing: HashRing{},
+		hashFunc: function,
+		replicas: replicas,
+		RWLock:   sync.RWMutex{},
+		conf:     nil,
+	}
+	return lb
+}
+
+func (lb *ConsistentHashLb) Add(params ...string) error {
+	if len(params) == 0 {
+		return errors.New("params length is at least 1")
+	}
+	ip := params[0]
+
+	lb.RWLock.Lock()
+	defer lb.RWLock.Unlock()
+
+	for i := 0; i < lb.replicas; i++ {
+		hash := lb.hashFunc([]byte(strconv.Itoa(i) + ip))
+		lb.hashRing = append(lb.hashRing, hash)
+		lb.hashMap[hash] = ip
+	}
+	sort.Sort(lb.hashRing) // easy to binary search
+
+	return nil
+}
+
+func (lb *ConsistentHashLb) Rmv(params ...string) error {
+	// TODO
+	return nil
+}
+
+func (lb *ConsistentHashLb) Get(key string) (string, error) {
+	if len(lb.hashRing) == 0 {
+		return "", errors.New("no available ip")
+	}
+	keyHash := lb.hashFunc([]byte(key))
+
+	idx := sort.Search(len(lb.hashRing), func(i int) bool {
+		return lb.hashRing[i] >= keyHash
+	})
+	if idx == len(lb.hashRing) {
+		idx = 0
+	}
+
+	lb.RWLock.Lock()
+	lb.RWLock.Unlock()
+
+	hash := lb.hashRing[idx]
+	ip := lb.hashMap[hash]
+	return ip, nil
+}
+
+func (lb *ConsistentHashLb) Register(conf load_balance.LoadBalanceConf) {
+	lb.conf = conf
+	lb.conf.Attach(lb)
+}
+
+func (lb *ConsistentHashLb) Subscribe() {
+	if conf, ok := lb.conf.(*lb_conf.ClientSvcDiscoveryLbConf); ok {
+		lb.hashMap = map[uint32]string{}
+		lb.hashRing = HashRing{}
+		for _, pair := range conf.GetConf() {
+			lb.Add(pair.Ip, strconv.Itoa(pair.Weight))
+		}
+	}
+}

--- a/load_balance/lb_algos/random.go
+++ b/load_balance/lb_algos/random.go
@@ -1,0 +1,77 @@
+package lb_algos
+
+import (
+	"github.com/LotteWong/giotto-gateway/load_balance"
+	"github.com/LotteWong/giotto-gateway/load_balance/lb_conf"
+	"github.com/pkg/errors"
+	"math/rand"
+	"strconv"
+)
+
+type RandomLb struct {
+	ips  []string
+	idx  int
+	conf load_balance.LoadBalanceConf
+}
+
+func NewRandomLb() *RandomLb {
+	return &RandomLb{
+		ips:  []string{},
+		idx:  0,
+		conf: nil,
+	}
+}
+
+func (lb *RandomLb) Add(params ...string) error {
+	if len(params) == 0 {
+		return errors.New("params length is at least 1")
+	}
+	ip := params[0]
+
+	lb.ips = append(lb.ips, ip)
+	return nil
+}
+
+func (lb *RandomLb) Rmv(params ...string) error {
+	if len(params) == 0 {
+		return errors.New("params length is at least 1")
+	}
+	ip := params[0]
+
+	var newIps []string
+	for _, oldIp := range lb.ips {
+		if oldIp == ip {
+			continue
+		}
+		newIps = append(newIps, oldIp)
+	}
+	lb.ips = newIps
+
+	return nil
+}
+
+func (lb *RandomLb) Get(key string) (string, error) {
+	if len(lb.ips) == 0 {
+		return "", errors.New("no available ip")
+	}
+
+	lb.idx = rand.Intn(len(lb.ips))
+	ip := lb.ips[lb.idx]
+
+	return ip, nil
+}
+
+func (lb *RandomLb) Register(conf load_balance.LoadBalanceConf) {
+	lb.conf = conf
+	lb.conf.Attach(lb)
+}
+
+// Subscribe is for observer to subscribe from subject
+func (lb *RandomLb) Subscribe() {
+	if conf, ok := lb.conf.(*lb_conf.ClientSvcDiscoveryLbConf); ok {
+		lb.ips = []string{}
+		for _, pair := range conf.GetConf() {
+			lb.Add(pair.Ip, strconv.Itoa(pair.Weight))
+		}
+	}
+}

--- a/load_balance/lb_algos/round_robin.go
+++ b/load_balance/lb_algos/round_robin.go
@@ -1,0 +1,80 @@
+package lb_algos
+
+import (
+	"github.com/LotteWong/giotto-gateway/load_balance"
+	"github.com/LotteWong/giotto-gateway/load_balance/lb_conf"
+	"github.com/pkg/errors"
+	"strconv"
+)
+
+type RoundRobinLb struct {
+	ips  []string
+	idx  int
+	conf load_balance.LoadBalanceConf
+}
+
+func NewRoundRobinLb() *RoundRobinLb {
+	return &RoundRobinLb{
+		ips:  []string{},
+		idx:  0,
+		conf: nil,
+	}
+}
+
+func (lb *RoundRobinLb) Add(params ...string) error {
+	if len(params) == 0 {
+		return errors.New("params length is at least 1")
+	}
+	ip := params[0]
+
+	lb.ips = append(lb.ips, ip)
+	return nil
+}
+
+func (lb *RoundRobinLb) Rmv(params ...string) error {
+	if len(params) == 0 {
+		return errors.New("params length is at least 1")
+	}
+	ip := params[0]
+
+	var newIps []string
+	for _, oldIp := range lb.ips {
+		if oldIp == ip {
+			continue
+		}
+		newIps = append(newIps, oldIp)
+	}
+	lb.ips = newIps
+
+	return nil
+}
+
+func (lb *RoundRobinLb) Get(key string) (string, error) {
+	if len(lb.ips) == 0 {
+		return "", errors.New("no available ip")
+	}
+
+	ipLen := len(lb.ips)
+	if lb.idx >= ipLen {
+		lb.idx = 0
+	}
+	ip := lb.ips[lb.idx]
+	lb.idx = (lb.idx + 1) % ipLen
+
+	return ip, nil
+}
+
+func (lb *RoundRobinLb) Register(conf load_balance.LoadBalanceConf) {
+	lb.conf = conf
+	lb.conf.Attach(lb)
+}
+
+// Subscribe is for observer to subscribe from subject
+func (lb *RoundRobinLb) Subscribe() {
+	if conf, ok := lb.conf.(*lb_conf.ClientSvcDiscoveryLbConf); ok {
+		lb.ips = []string{}
+		for _, pair := range conf.GetConf() {
+			lb.Add(pair.Ip, strconv.Itoa(pair.Weight))
+		}
+	}
+}

--- a/load_balance/lb_algos/weight_round_robin.go
+++ b/load_balance/lb_algos/weight_round_robin.go
@@ -1,0 +1,105 @@
+package lb_algos
+
+import (
+	"github.com/LotteWong/giotto-gateway/load_balance"
+	"github.com/LotteWong/giotto-gateway/load_balance/lb_conf"
+	"github.com/pkg/errors"
+	"strconv"
+)
+
+type WeightRoundRobinLb struct {
+	nodes []*IpAndWeightNode
+	idx   int
+	conf  load_balance.LoadBalanceConf
+}
+
+type IpAndWeightNode struct {
+	ip              string
+	weight          int
+	currentWeight   int // may greater than weight
+	effectiveWeight int // must less than or equal to weight
+}
+
+func NewWeightRoundRobinLb() *WeightRoundRobinLb {
+	return &WeightRoundRobinLb{
+		nodes: []*IpAndWeightNode{},
+		idx:   0,
+		conf:  nil,
+	}
+}
+
+func (lb *WeightRoundRobinLb) Add(params ...string) error {
+	if len(params) != 2 {
+		return errors.New("params length should be 2")
+	}
+	ip := params[0]
+	weight, err := strconv.Atoi(params[1])
+	if err != nil {
+		return err
+	}
+
+	lb.nodes = append(lb.nodes, &IpAndWeightNode{
+		ip:              ip,
+		weight:          weight,
+		effectiveWeight: weight,
+	})
+
+	return nil
+}
+
+func (lb *WeightRoundRobinLb) Rmv(params ...string) error {
+	if len(params) == 0 {
+		return errors.New("params length is at least 1")
+	}
+	ip := params[0]
+
+	var newNodes []*IpAndWeightNode
+	for _, oldNode := range lb.nodes {
+		if oldNode.ip == ip {
+			continue
+		}
+		newNodes = append(newNodes, oldNode)
+	}
+	lb.nodes = newNodes
+
+	return nil
+}
+
+func (lb *WeightRoundRobinLb) Get(key string) (string, error) {
+	var bestNode *IpAndWeightNode
+	var totalWeight int
+
+	for _, node := range lb.nodes {
+		totalWeight += node.effectiveWeight
+
+		node.currentWeight += node.effectiveWeight
+		if node.effectiveWeight < node.weight {
+			node.effectiveWeight++
+		}
+
+		if bestNode == nil || node.currentWeight > bestNode.currentWeight {
+			bestNode = node
+		}
+	}
+
+	if bestNode == nil {
+		return "", errors.New("no available ip")
+	} else {
+		bestNode.currentWeight -= totalWeight
+		return bestNode.ip, nil
+	}
+}
+
+func (lb *WeightRoundRobinLb) Register(conf load_balance.LoadBalanceConf) {
+	lb.conf = conf
+	lb.conf.Attach(lb)
+}
+
+func (lb *WeightRoundRobinLb) Subscribe() {
+	if conf, ok := lb.conf.(*lb_conf.ClientSvcDiscoveryLbConf); ok {
+		lb.nodes = []*IpAndWeightNode{}
+		for _, pair := range conf.GetConf() {
+			lb.Add(pair.Ip, strconv.Itoa(pair.Weight))
+		}
+	}
+}

--- a/load_balance/lb_conf/client_svc_discovery.go
+++ b/load_balance/lb_conf/client_svc_discovery.go
@@ -1,0 +1,105 @@
+package lb_conf
+
+import (
+	"github.com/LotteWong/giotto-gateway/constants"
+	"github.com/LotteWong/giotto-gateway/load_balance"
+	"net"
+	"reflect"
+	"sort"
+	"time"
+)
+
+type ClientSvcDiscoveryLbConf struct {
+	// observers
+	lbs []load_balance.LoadBalance
+	// configs
+	activeIps   []string
+	ipWeightMap map[string]int
+	// others
+	format string
+}
+
+func NewClientSvcDiscoveryLbConf(activeIps []string, ipWeightMap map[string]int, format string) *ClientSvcDiscoveryLbConf {
+	// initiate conf
+	conf := &ClientSvcDiscoveryLbConf{
+		lbs:         []load_balance.LoadBalance{},
+		ipWeightMap: ipWeightMap,
+		activeIps:   activeIps,
+		format:      format,
+	}
+	// publish conf
+	conf.Publish()
+
+	return conf
+}
+
+// Attach is for subject to attach observer
+func (c *ClientSvcDiscoveryLbConf) Attach(lb load_balance.LoadBalance) {
+	c.lbs = append(c.lbs, lb)
+}
+
+func (c *ClientSvcDiscoveryLbConf) Notify() {
+	for _, lb := range c.lbs {
+		lb.Subscribe()
+	}
+}
+
+// Publish is for subject to publish to observer
+func (c *ClientSvcDiscoveryLbConf) Publish() {
+	// TODO: use job instead of loop
+	go func() {
+		connErrMap := map[string]int{}
+		for {
+			var newActiveIps []string
+
+			// gateway client health check backend server
+			for ip, _ := range c.ipWeightMap {
+				conn, err := net.DialTimeout("tcp", ip, time.Duration(constants.DefaultDialTimeout)*time.Second)
+
+				if err == nil {
+					// if dial succeed, set ip's connection error nums to 0
+					conn.Close()
+					connErrMap[ip] = 0
+				} else {
+					// if dial failed, increase ip's connection error nums
+					if _, ok := connErrMap[ip]; ok {
+						connErrMap[ip] += 1
+					} else {
+						connErrMap[ip] = 1
+					}
+				}
+
+				if connErrMap[ip] < constants.DefaultDialMaxErrNum {
+					newActiveIps = append(newActiveIps, ip)
+				}
+			}
+
+			// update active ips and Notify load balances
+			sort.Strings(newActiveIps)
+			sort.Strings(c.activeIps)
+			if !reflect.DeepEqual(newActiveIps, c.activeIps) {
+				c.activeIps = newActiveIps
+				c.Notify()
+			}
+
+			time.Sleep(time.Duration(constants.DefaultDialInterval) * time.Second)
+		}
+	}()
+}
+
+func (c *ClientSvcDiscoveryLbConf) GetConf() []*load_balance.IpAndWeight {
+	var confs []*load_balance.IpAndWeight
+
+	for _, ip := range c.activeIps {
+		weight, ok := c.ipWeightMap[ip]
+		if !ok {
+			weight = 50 // set default weight to 50
+		}
+		confs = append(confs, &load_balance.IpAndWeight{
+			Ip:     ip,
+			Weight: weight,
+		})
+	}
+
+	return confs
+}

--- a/load_balance/lb_conf/server_svc_discovery.go
+++ b/load_balance/lb_conf/server_svc_discovery.go
@@ -1,0 +1,4 @@
+package lb_conf
+
+type ServerSvcDiscoveryLbConf struct {
+}

--- a/models/po/load_balance.go
+++ b/models/po/load_balance.go
@@ -1,6 +1,9 @@
 package po
 
-import "strings"
+import (
+	"github.com/LotteWong/giotto-gateway/load_balance"
+	"strings"
+)
 
 type LoadBalance struct {
 	Id            int64  `json:"id" gorm:"primary_key" description:"自增主键"`
@@ -33,4 +36,9 @@ func (t *LoadBalance) GetDisabledIpList() []string {
 
 func (t *LoadBalance) GetWeightList() []string {
 	return strings.Split(t.WeightList, ",")
+}
+
+type LoadBalanceDetail struct {
+	LoadBalancer load_balance.LoadBalance `json:"info" description:"负载均衡器"`
+	ServiceName  string                   `json:"service_name" description:"服务名称"`
 }

--- a/service/lb_service.go
+++ b/service/lb_service.go
@@ -1,0 +1,96 @@
+package service
+
+import (
+	"fmt"
+	"github.com/LotteWong/giotto-gateway/constants"
+	"github.com/LotteWong/giotto-gateway/dao"
+	"github.com/LotteWong/giotto-gateway/load_balance"
+	"github.com/LotteWong/giotto-gateway/load_balance/lb_conf"
+	"github.com/LotteWong/giotto-gateway/models/po"
+	"strconv"
+	"sync"
+)
+
+var lbService *LbService
+
+type LbService struct {
+	LoadBalanceMap   map[string]*po.LoadBalanceDetail
+	LoadBalanceSlice []*po.LoadBalanceDetail
+	RWLock           sync.RWMutex
+
+	loadBalanceOperator *dao.LoadBalanceOperator
+}
+
+func NewLbService() *LbService {
+	service := &LbService{
+		LoadBalanceMap:      map[string]*po.LoadBalanceDetail{},
+		LoadBalanceSlice:    []*po.LoadBalanceDetail{},
+		RWLock:              sync.RWMutex{},
+		loadBalanceOperator: dao.NewLoadBalanceOperator(),
+	}
+	return service
+}
+
+func GetLbService() *LbService {
+	if lbService == nil {
+		lbService = NewLbService()
+	}
+	return lbService
+}
+
+func (s *LbService) GetLbWithConfForSvc(svc *po.ServiceDetail) (load_balance.LoadBalance, error) {
+	// hit in cache, use cache data
+	for _, lb := range s.LoadBalanceSlice {
+		if lb.ServiceName == svc.Info.ServiceName {
+			return lb.LoadBalancer, nil
+		}
+	}
+
+	// miss in cache, new a load balance with config
+	activeIps := svc.LoadBalance.GetEnabledIpList()
+	weights := svc.LoadBalance.GetWeightList()
+	ipWeightMap := map[string]int{}
+	for idx, ip := range activeIps {
+		weight, err := strconv.Atoi(weights[idx])
+		if err != nil {
+			return nil, err
+		}
+		ipWeightMap[ip] = weight
+	}
+
+	var schema string
+	switch svc.Info.ServiceType {
+	case constants.ServiceTypeHttp:
+		switch svc.HttpRule.NeedHttps {
+		case constants.Enable:
+			schema = "https://"
+		case constants.Disable:
+			schema = "http://"
+		default:
+			schema = "http://"
+		}
+	case constants.ServiceTypeTcp:
+		schema = ""
+	case constants.ServiceTypeGrpc:
+		schema = ""
+	default:
+		schema = ""
+	}
+	format := fmt.Sprintf("%s%s", schema, "%s")
+
+	conf := lb_conf.NewClientSvcDiscoveryLbConf(activeIps, ipWeightMap, format)
+	lbr := load_balance.LoadBalanceWithConfFactory(load_balance.LbType(svc.LoadBalance.RoundType), conf)
+
+	// miss in cache, write back to cache
+	lb := &po.LoadBalanceDetail{
+		LoadBalancer: lbr,
+		ServiceName:  svc.Info.ServiceName,
+	}
+
+	s.LoadBalanceSlice = append(s.LoadBalanceSlice, lb)
+	s.RWLock.Lock()
+	defer s.RWLock.Unlock()
+	s.LoadBalanceMap[svc.Info.ServiceName] = lb
+
+	return lbr, nil
+}


### PR DESCRIPTION
1. load balance as observer with four algorithms (random/round
   robin/weight round robin/consistent hash)
2. load balance as subject with two mode (client service
   discovery/server service discovery)
3. make a factory to produce load balance and a factory to produce load
   balance with config
4. cache the relationship between service and load balance in memory