### PR TITLE
feat: support websocket protocol

### DIFF
--- a/http_proxy_middleware/http_jwt_auth.go
+++ b/http_proxy_middleware/http_jwt_auth.go
@@ -24,7 +24,14 @@ func HttpJwtAuthMiddleware() gin.HandlerFunc {
 		httpServiceDetail := httpServiceInterface.(*po.ServiceDetail)
 
 		// parse authorization to get jwt
-		pair := strings.Split(c.GetHeader("Authorization"), " ")
+		var authHeader string
+		if c.GetHeader("Authorization") != "" {
+			authHeader = c.GetHeader("Authorization")
+		}
+		if c.GetHeader("Sec-Websocket-Protocol") != "" {
+			authHeader = c.GetHeader("Sec-Websocket-Protocol")
+		}
+		pair := strings.Split(authHeader, " ")
 		if len(pair) != 2 {
 			common_middleware.ResponseError(c, http.StatusInternalServerError, errors.New("can not get jwt from authorization header"))
 			c.Abort()

--- a/http_proxy_middleware/http_reverse_proxy.go
+++ b/http_proxy_middleware/http_reverse_proxy.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"github.com/LotteWong/giotto-gateway-core/common_middleware"
+	"github.com/LotteWong/giotto-gateway-core/constants"
 	"github.com/LotteWong/giotto-gateway-core/models/po"
 	"github.com/LotteWong/giotto-gateway-core/reverse_proxy"
 	"github.com/LotteWong/giotto-gateway-core/service"
@@ -35,7 +36,13 @@ func HttpReverseProxyMiddleware() gin.HandlerFunc {
 		}
 
 		// use reverse proxy to serve http
-		proxy := reverse_proxy.NewHttpReverseProxy(c, lb, trans)
+		var scheme string
+		if httpServiceDetail.HttpRule.NeedHttps == constants.Enable {
+			scheme = "https://"
+		} else {
+			scheme = "http://"
+		}
+		proxy := reverse_proxy.NewHttpReverseProxy(c, lb, trans, schema)
 		proxy.ServeHTTP(c.Writer, c.Request)
 
 		// abort the original server to be accessed

--- a/reverse_proxy/http_reverse_proxy.go
+++ b/reverse_proxy/http_reverse_proxy.go
@@ -12,7 +12,7 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-func NewHttpReverseProxy(ctx *gin.Context, lb load_balance.LoadBalance, trans *http.Transport) *httputil.ReverseProxy {
+func NewHttpReverseProxy(ctx *gin.Context, lb load_balance.LoadBalance, trans *http.Transport, scheme string) *httputil.ReverseProxy {
 	// convert the source request to target request
 	director := func(req *http.Request) {
 		var err error
@@ -21,7 +21,7 @@ func NewHttpReverseProxy(ctx *gin.Context, lb load_balance.LoadBalance, trans *h
 		if err != nil {
 			panic(err)
 		}
-		targetUrl, err := url.Parse("http://" + targetStr)
+		targetUrl, err := url.Parse(scheme + targetStr)
 		if err != nil {
 			panic(err)
 		}

--- a/service/svc_service.go
+++ b/service/svc_service.go
@@ -64,7 +64,7 @@ func (s *SvcService) HttpProxyAccessService(ctx *gin.Context) (*po.ServiceDetail
 	path := ctx.Request.URL.Path
 	var host string
 	colonIndex := strings.Index(ctx.Request.Host, ":")
-	if colonIndex != -1 {
+	if colonIndex == -1 {
 		// host doesn't contain port
 		host = ctx.Request.Host
 	} else {

--- a/service/trans_service.go
+++ b/service/trans_service.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"crypto/tls"
 	"net"
 	"net/http"
 	"sync"
@@ -68,6 +69,7 @@ func (s *TransService) GetTransForSvc(svc *po.ServiceDetail) (*http.Transport, e
 		MaxIdleConns:          svc.LoadBalance.UpstreamMaxIdle,
 		IdleConnTimeout:       time.Duration(svc.LoadBalance.UpstreamIdleTimeout) * time.Second,
 		TLSHandshakeTimeout:   time.Duration(constants.DefaultTLSHandshakeTimeout) * time.Second,
+		TLSClientConfig:       &tls.Config{InsecureSkipVerify: true},
 	}
 
 	// miss in cache, write back to cache


### PR DESCRIPTION
1. upgrade to websocket protocol with bearer token in
set-websocket-protocol header field
2. set reverse proxy request's schema according to service type (https ->
https://, http -> http://, ws -> http://)
3. skip server tls verification to avoid `x509: certificate signed by
unknown authority` error