### PR TITLE
feat: improve http proxy access of scheme and headers

### DIFF
--- a/http_proxy_middleware/http_proxy_access.go
+++ b/http_proxy_middleware/http_proxy_access.go
@@ -16,8 +16,16 @@ func HttpProxyAccessMiddleware() gin.HandlerFunc {
 			c.Abort()
 			return
 		}
-		// log.Printf("matched http service: %s\n", utils.Obj2Json(httpService))
 		c.Set("service", httpService)
+
+		scheme, err := service.GetSvcService().HttpProxyAccessScheme(c, httpService)
+		if err != nil {
+			common_middleware.ResponseError(c, http.StatusInternalServerError, err)
+			c.Abort()
+			return
+		}
+		c.Set("scheme", scheme)
+
 		c.Next()
 	}
 }


### PR DESCRIPTION
1. check WebSocket/HTTP1.1/HTTP2's headers
2. check HTTPS's scheme
3. move check logic from http_reverse_proxy middleware to
http_proxy_access middleware